### PR TITLE
Don't write HELP line if description is an empty string

### DIFF
--- a/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
+++ b/implementation/src/main/java/io/smallrye/metrics/exporters/PrometheusExporter.java
@@ -307,7 +307,7 @@ public class PrometheusExporter implements Exporter {
 
     private void writeHelpLine(StringBuffer sb, MetricRegistry.Type scope, String key, Metadata md, String suffix) {
         // Only write this line if we actually have a description in metadata
-        if (writeHelpLine && md.getDescription().isPresent()) {
+        if (writeHelpLine && !md.getDescription().orElse("").isEmpty()) {
             sb.append("# HELP ");
             getNameWithScopeAndSuffix(sb, scope, key, suffix);
             sb.append(md.getDescription().get());


### PR DESCRIPTION
When the metric is declared using an annotation and the `description` param is not specified, Java compiler defaults it to an empty string, not null. Treat empty string as missing description.